### PR TITLE
fix: Theme switcher

### DIFF
--- a/components/misc/theme-switch.tsx
+++ b/components/misc/theme-switch.tsx
@@ -6,7 +6,7 @@ import { useTheme } from "next-themes";
 import { useEffect, useState } from "react";
 
 export default function ThemeSwitch() {
-  const { theme, setTheme, resolvedTheme } = useTheme();
+  const { setTheme, resolvedTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
@@ -18,7 +18,7 @@ export default function ThemeSwitch() {
   }
 
   function onThemeChange() {
-    setTheme(theme === "dark" ? "light" : "dark");
+    setTheme(resolvedTheme === "dark" ? "light" : "dark");
   }
 
   return (


### PR DESCRIPTION
Uses `resolvedTheme` instead of `theme` to fix the bug with theme switch.

Fixes: #29 